### PR TITLE
Use ellipsis overflow in PDF tables

### DIFF
--- a/src/lib/pdf-exporter.ts
+++ b/src/lib/pdf-exporter.ts
@@ -11,7 +11,7 @@
             cellPadding: 1,
             lineColor: [200,200,200],
             lineWidth: 0.25,
-            overflow: 'linebreak',
+            overflow: 'ellipsize',
             tableWidth: 'wrap'
         },
         headStyles: {

--- a/src/lib/pdf-exporter.ts
+++ b/src/lib/pdf-exporter.ts
@@ -11,7 +11,7 @@
             cellPadding: 1,
             lineColor: [200,200,200],
             lineWidth: 0.25,
-            overflow: 'ellipsize',
+            overflow: 'ellipsize', // prevent multi-line cells
             tableWidth: 'wrap'
         },
         headStyles: {

--- a/src/lib/schedule-pdf-exporter.ts
+++ b/src/lib/schedule-pdf-exporter.ts
@@ -174,7 +174,7 @@ export function exportScheduleToPDF(data: ScheduleExportData): void {
         styles: {
             cellPadding: 4,
             fontSize: 9,
-            overflow: 'ellipsize',
+            overflow: 'ellipsize', // prevent multi-line cells
             lineWidth: 0.5,
             lineColor: [200, 200, 200]
         },
@@ -351,7 +351,7 @@ export function exportConsolidatedScheduleToPDF(allLocationData: ScheduleExportD
         styles: {
             cellPadding: 2.5, // Global cell padding
             fontSize: 8, // Default font size for cell text if not overridden
-            overflow: 'ellipsize',
+            overflow: 'ellipsize', // prevent multi-line cells
             lineWidth: 0.5,
             lineColor: [200, 200, 200]
         },

--- a/src/lib/schedule-pdf-exporter.ts
+++ b/src/lib/schedule-pdf-exporter.ts
@@ -174,7 +174,7 @@ export function exportScheduleToPDF(data: ScheduleExportData): void {
         styles: {
             cellPadding: 4,
             fontSize: 9,
-            overflow: 'linebreak',
+            overflow: 'ellipsize',
             lineWidth: 0.5,
             lineColor: [200, 200, 200]
         },
@@ -351,7 +351,7 @@ export function exportConsolidatedScheduleToPDF(allLocationData: ScheduleExportD
         styles: {
             cellPadding: 2.5, // Global cell padding
             fontSize: 8, // Default font size for cell text if not overridden
-            overflow: 'linebreak',
+            overflow: 'ellipsize',
             lineWidth: 0.5,
             lineColor: [200, 200, 200]
         },


### PR DESCRIPTION
## Summary
- prevent cell text from wrapping by using `ellipsize` overflow in PDF exporter tables

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter`)*
- `npm run typecheck` *(fails: Cannot find name 'doc'; Spread types may only be created from object types)*
- `node - <<'NODE' ...` (generates sample PDF with ellipsis overflow)


------
https://chatgpt.com/codex/tasks/task_e_689ed565c3c883269478e5ea9778b36c